### PR TITLE
Fix admin not being able to delete

### DIFF
--- a/code/model/Newsletter.php
+++ b/code/model/Newsletter.php
@@ -392,7 +392,7 @@ class Newsletter extends DataObject implements CMSPreviewable{
 	public function canDelete($member = null) {
 		$can = parent::canDelete($member);
 		if($this->Status !== 'Sending') return $can;
-		else return false;
+		else return Permission::check('ADMIN');
 	}
 
 


### PR DESCRIPTION
In some cases a message could fail validation and be left in an inconsistent state.

e.g. if a message was created, but a crash or validation issue caused the request to fail before the message could be enqueued, then it'll be left in the "sending" state without actually being prepared for sending.
