### PR TITLE
Corrected "Required" attribute display

### DIFF
--- a/code/controller/UnsubscribeController.php
+++ b/code/controller/UnsubscribeController.php
@@ -152,7 +152,7 @@ class UnsubscribeController extends Page_Controller
         }
 
         return $this->customise(array(
-            'Title' => _t('UNSUBSCRIBEDTITLE', 'Unsubscribed'),
+            'Title' => _t('Newsletter.UNSUBSCRIBEDTITLE', 'Unsubscribed'),
             'Content' => $content,
             'Form' => $form
         ))->renderWith('Page');

--- a/code/pagetypes/SubscriptionPage.php
+++ b/code/pagetypes/SubscriptionPage.php
@@ -307,7 +307,7 @@ class SubscriptionPage_Controller extends Page_Controller
         );
 
         if (!empty($requiredFields)) {
-            $required = new RequiredFields($requiredFields);
+            $required = new RequiredFields(array_keys($requiredFields));
         } else {
             $required = null;
         }


### PR DESCRIPTION
the `$requiredFields` will now return a correct HTML (example `<input>` tag) with attribute `required` if this field is required.
