### PR TITLE
Enhancement/recipient data extension

### DIFF
--- a/src/Model/Recipient.php
+++ b/src/Model/Recipient.php
@@ -170,6 +170,8 @@ class Recipient extends DataObject
         $fields->makeFieldReadonly('ValidateHashExpired');
         $fields->makeFieldReadonly('Verified');
 
+        $this->extend("updateRecipientFields", $fields);
+
         return $fields;
     }
 


### PR DESCRIPTION
Add ability to extend on Recipient Model for CMS Fields.

Previous version of newsletter module allowed manual verify checkboxing of Recipient out of the box, client wants to retain that ability.
